### PR TITLE
Remove temporary file after the command runs

### DIFF
--- a/project/docker/services/web/entry
+++ b/project/docker/services/web/entry
@@ -20,11 +20,13 @@ fi
 if [ -f /work/tmp/.run_bundle_update ];
 then
   bundle update --jobs 3 --retry 3
+  rm /work/tmp/.run_bundle_update
 fi
 
 if [ -f /work/tmp/.run_bundle_install ];
 then
   bundle install --jobs 3 --retry 3
+  rm /work/tmp/.run_bundle_install
 fi
 
 # Starts spring server if running in development.


### PR DESCRIPTION
I think it'll be better to remove the temporary files after the command runs with success.